### PR TITLE
Feat get post by categories #19

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    env:
+      GRAPHCMS_TOKEN: ${{secrets.GRAPHCMS_TOKEN}}
+      NEXT_PUBLIC_GRAPHCMS_ENDPOINT: ${{secrets.NEXT_PUBLIC_GRAPHCMS_ENDPOINT}}
 
     strategy:
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -130,5 +130,3 @@ dist
 .pnp.*
 
 TODO
-
-tests/

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "next build",
     "start": "next start",
     "test": "jest --watch --detectOpenHandles",
-    "test:ci": "jest --coverage --silent --ci",
+    "test:ci": "jest --coverage --silent --ci ",
     "update-snapshot": "jest --updateSnapshot",
     "lint": "next lint --dir src",
     "prepare": "husky install",

--- a/src/components/categories/tests/__snapshots__/categories.test.tsx.snap
+++ b/src/components/categories/tests/__snapshots__/categories.test.tsx.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Categories should render the Categories component 1`] = `
+<div>
+  <div
+    class="bg-white shadow-lg rounded-lg p-8 mb-8 pb-12"
+  >
+    <h3
+      class="text-xl mb-8 font-semibold border-b pb-4"
+    >
+      Categories
+    </h3>
+  </div>
+</div>
+`;

--- a/src/components/categories/tests/categories.test.tsx
+++ b/src/components/categories/tests/categories.test.tsx
@@ -1,0 +1,11 @@
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+import { Categories } from "../..";
+
+describe("Categories", () => {
+  it("should render the Categories component", () => {
+    const { container } = render(<Categories />);
+    expect(container).toBeInTheDocument();
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/src/components/posts/RichTextWrapper.tsx
+++ b/src/components/posts/RichTextWrapper.tsx
@@ -91,7 +91,7 @@ export default function RichTextWrapper({ content }: RichContextProps) {
           table_row: ({ children }) => <tr> {children}</tr>,
           list_item_child: ({ children }) => <Fragment> {children}</Fragment>,
           blockquote: ({ children }) => (
-            <figure>
+            <figure data-testid="quote">
               <blockquote>
                 <p className="text-lg font-medium">{children}</p>
               </blockquote>

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -62,3 +62,33 @@ export const categories = gql`
     }
   }
 `;
+
+export const categoryPost = gql`
+  query GetCategoryPost($slug: String!) {
+    posts(where: { categories_some: { slug: $slug } }) {
+      title
+      slug
+      id
+      excerpt
+      createdAt
+      categories {
+        id
+        name
+        slug
+      }
+      featuredImage {
+        url
+        height
+        width
+      }
+      author {
+        bio
+        id
+        name
+        photo {
+          url
+        }
+      }
+    }
+  }
+`;

--- a/src/pages/category/[slug].tsx
+++ b/src/pages/category/[slug].tsx
@@ -35,6 +35,6 @@ export async function getStaticPaths() {
   const categories = await getCategories();
   return {
     paths: categories.map(({ slug }) => ({ params: { slug } })),
-    fallback: true,
+    fallback: false,
   };
 }

--- a/src/pages/category/[slug].tsx
+++ b/src/pages/category/[slug].tsx
@@ -1,0 +1,40 @@
+import { GetStaticProps } from "next";
+import { ParsedUrlQuery } from "querystring";
+import React from "react";
+import { Categories, PostCard } from "../../components";
+import { getCategories, getCategoryPosts } from "../../services";
+import { BlogPostData } from "../../typedefs";
+
+export default function CategoryPosts({ posts }: BlogPostData) {
+  return (
+    <div className="container mx-auto px-10 mb-8">
+      <div className="grid grid-cols-1 lg:grid-cols-12 gap-12">
+        <div className="col-span-1 lg:col-span-8">
+          {posts.map((post, index) => (
+            <PostCard key={index} post={post} />
+          ))}
+        </div>
+        <div className="col-span-1 lg:col-span-4">
+          <div className="relative lg:sticky top-8">
+            <Categories />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const getStaticProps: GetStaticProps = async ({ params }) => {
+  const slug = (params as ParsedUrlQuery).slug as string;
+  const posts = await getCategoryPosts(slug);
+  return {
+    props: { posts },
+  };
+};
+export async function getStaticPaths() {
+  const categories = await getCategories();
+  return {
+    paths: categories.map(({ slug }) => ({ params: { slug } })),
+    fallback: true,
+  };
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,6 +1,6 @@
 import { request } from "graphql-request";
 import { graphqlAPI } from "../constants";
-import { allPosts, categories, postDetails } from "../graphql";
+import { allPosts, categories, categoryPost, postDetails } from "../graphql";
 import {
   BlogPostData,
   BlogPost,
@@ -25,4 +25,11 @@ export const getPostDetails = async (
 export const getCategories = async (): Promise<PostCategory[]> => {
   const results: PostCategories = await request(graphqlAPI, categories);
   return results.categories;
+};
+
+export const getCategoryPosts = async (slug: string): Promise<BlogPost[]> => {
+  const categoryPosts: BlogPostData = await request(graphqlAPI, categoryPost, {
+    slug,
+  });
+  return categoryPosts.posts;
 };

--- a/src/services/tests/services.test.ts
+++ b/src/services/tests/services.test.ts
@@ -1,0 +1,30 @@
+import { getCategories, getPostDetails, getPosts } from "../index";
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => setTimeout(() => resolve(), 10000));
+});
+
+describe("Services", () => {
+  jest.setTimeout(30000);
+  describe("Posts", () => {
+    it("fetch all post data", async () => {
+      const data = await getPosts();
+      expect(data).toBeDefined();
+      expect(Array.isArray(data)).toBe(true);
+      expect(data).not.toBeNull();
+    });
+
+    it("fetch single post detail", async () => {
+      const data = await getPostDetails("javascript-promises");
+      expect(data).toBeDefined();
+      expect(data).not.toBeNull();
+    });
+
+    it("should return post categories", async () => {
+      const data = await getCategories();
+      expect(data).toBeDefined();
+      expect(Array.isArray(data)).toBe(true);
+      expect(data).not.toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
Get posts with identical categories

#### Description of Task to be completed?
* create UI to display  posts with identical categories
* fetch posts by categories from the API

#### How should this be manually tested?
*  clone the repo
* open a terminal on your PC and run git clone <repo_url>
*  cd into the project repo and run yarn install
* in the terminal, run yarn dev
 * open a browser and navigte to localhost:3000
 * click on a category in the header or right side bar.



#### What are the relevant azure board stories?
[[#19](https://hoxtygen.visualstudio.com/talksofcode.com/_boards/board/t/talksofcode.com%20Team/Stories/?workitem=19)]

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/19408669/197411920-d86c5025-edd1-4871-8472-d41c9afd663a.png)
![image](https://user-images.githubusercontent.com/19408669/197411981-aab5f819-009b-4e21-bd03-bdabcdfba4fd.png)


#### Questions: