### PR TITLE
Refactor: split queries fragments #24

### DIFF
--- a/src/components/comment/Comment.tsx
+++ b/src/components/comment/Comment.tsx
@@ -13,7 +13,7 @@ export default function Comment({ comment }: SingleComment) {
         on {moment(comment.createdAt).format("MMM DD, YYYY")}
       </p>
       <p
-        data-testId="commenter-comment"
+        data-testid="commenter-comment"
         className="whitespace-pre-line text-gray-600 w-full"
       >
         {parse(comment.comment)}

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -1,68 +1,96 @@
 import { gql } from "graphql-request";
 
-export const allPosts = gql`
-  query GetPosts {
-    posts {
+const AUTHOR_FRAGMENT = gql`
+  fragment AuthorInfo on Post {
+    author {
       id
-      slug
-      title
-      excerpt
-      createdAt
-      author {
-        bio
-        name
-        photo {
-          url
-        }
-      }
-      featuredImage {
+      bio
+      name
+      photo {
         url
-        height
-        width
-      }
-      content {
-        raw
       }
     }
   }
 `;
 
-export const postDetails = gql`
-  query GetPostDetails($slug: String!) {
-    post(where: { slug: $slug }) {
+const COMMENT_FRAGMENT = gql`
+  fragment Comment on Post {
+    comments {
       id
+      name
+      email
+      comment
       createdAt
+    }
+  }
+`;
+
+const CATEGORY_FRAGMENT = gql`
+  fragment Categories on Post {
+    categories {
+      id
+      name
       slug
-      title
-      excerpt
-      comments {
-        id
-        name
-        email
-        comment
-        createdAt
-      }
-      author {
-        id
-        bio
-        name
-        photo {
-          url
-        }
-      }
-      featuredImage {
-        url
-      }
-      categories {
-        id
-        name
-        slug
-      }
+    }
+  }
+`;
+
+const FEATURED_IMAGE_FRAGMENT = gql`
+  fragment featuredImage on Post {
+    featuredImage {
+      url
+      height
+      width
+    }
+  }
+`;
+
+const POST_FRAGMENT = gql`
+  fragment PostInfo on Post {
+    createdAt
+    excerpt
+    id
+    slug
+    title
+  }
+`;
+
+export const allPosts = gql`
+  query GetPosts {
+    posts {
+      ...PostInfo
+      ...AuthorInfo
+      ...featuredImage
       content {
         raw
       }
     }
   }
+  ${AUTHOR_FRAGMENT}
+  ${FEATURED_IMAGE_FRAGMENT}
+  ${POST_FRAGMENT}
+`;
+
+export const postDetails = gql`
+  query GetPostDetails($slug: String!) {
+    post(where: { slug: $slug }) {
+      ...PostInfo
+      ...AuthorInfo
+      ...Comment
+      ...Categories
+      featuredImage {
+        url
+      }
+
+      content {
+        raw
+      }
+    }
+  }
+  ${AUTHOR_FRAGMENT}
+  ${COMMENT_FRAGMENT}
+  ${CATEGORY_FRAGMENT}
+  ${POST_FRAGMENT}
 `;
 
 export const categories = gql`
@@ -78,45 +106,28 @@ export const categories = gql`
 export const categoryPost = gql`
   query GetCategoryPost($slug: String!) {
     posts(where: { categories_some: { slug: $slug } }) {
-      title
-      slug
-      id
-      excerpt
-      createdAt
-      categories {
-        id
-        name
-        slug
-      }
-      featuredImage {
-        url
-        height
-        width
-      }
-      author {
-        bio
-        id
-        name
-        photo {
-          url
-        }
-      }
+      ...PostInfo
+      ...AuthorInfo
+      ...Categories
+      ...featuredImage
     }
   }
+  ${AUTHOR_FRAGMENT}
+  ${CATEGORY_FRAGMENT}
+  ${FEATURED_IMAGE_FRAGMENT}
+  ${POST_FRAGMENT}
 `;
 
 export const recentPosts = gql`
   query GetRecentPosts {
     posts(orderBy: createdAt_ASC, last: 3) {
-      id
-      title
-      createdAt
-      slug
+      ...PostInfo
       featuredImage {
         url
       }
     }
   }
+  ${POST_FRAGMENT}
 `;
 
 export const similarPosts = gql`
@@ -128,15 +139,13 @@ export const similarPosts = gql`
       }
       last: 5
     ) {
-      id
-      title
-      createdAt
-      slug
+      ...PostInfo
       featuredImage {
         url
       }
     }
   }
+  ${POST_FRAGMENT}
 `;
 
 export const newCommentQuery = gql`


### PR DESCRIPTION
#### What does this PR do?
Break down long repetitive queries into smaller reusable fragments

#### Description of Task to be completed?
* break graphql queries into smaller fragments
* reuse and refactor fragments where appropriate

#### What are the relevant azure board stories?
[[#24](https://hoxtygen.visualstudio.com/talksofcode.com/_boards/board/t/talksofcode.com%20Team/Stories/?workitem=24)]

#### Screenshots (if appropriate)
![Fragment1](https://user-images.githubusercontent.com/19408669/199181804-4f9492c5-05cb-4120-a254-26934405d0fb.png)
![Fragment2](https://user-images.githubusercontent.com/19408669/199181810-6c1df982-e170-489f-9cfb-01962eaccce1.png)



#### Questions: